### PR TITLE
Implement #10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,45 +20,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
-name = "async-trait"
-version = "0.1.83"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.79",
-]
-
-[[package]]
-name = "attribute-derive"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c124f12ade4e670107b132722d0ad1a5c9790bcbc1b265336369ea05626b4498"
-dependencies = [
- "attribute-derive-macro",
- "proc-macro2",
- "quote",
- "syn 2.0.79",
-]
-
-[[package]]
-name = "attribute-derive-macro"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b217a07446e0fb086f83401a98297e2d81492122f5874db5391bd270a185f88"
-dependencies = [
- "collection_literals",
- "interpolator",
- "proc-macro-error",
- "proc-macro-utils",
- "proc-macro2",
- "quote",
- "quote-use",
- "syn 2.0.79",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -147,18 +108,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
-name = "collate"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a89a8f0a4e9c59e13d3999b960b937f816aacddca59ba22ce1ebf88a2ce4c8bd"
-
-[[package]]
-name = "collection_literals"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "186dce98367766de751c42c4f03970fc60fc012296e706ccbb9d5df9b6c1e271"
-
-[[package]]
 name = "counter"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -175,17 +124,6 @@ checksum = "15f9f7643e6fa6842f55898be3182c1e5b59447779e0dd55b50f9c601b2bf7c3"
 dependencies = [
  "derive_more",
  "dyn-clone",
-]
-
-[[package]]
-name = "derive-where"
-version = "1.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62d671cc41a825ebabc75757b62d3d168c577f9149b2d49ece1dad1f72119d25"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.79",
 ]
 
 [[package]]
@@ -234,23 +172,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
-name = "get-size"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b61e2dab7eedce93a83ab3468b919873ff16bac5a3e704011ff836d22b2120"
-
-[[package]]
-name = "get-size-derive"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13a1bcfb855c1f340d5913ab542e36f25a1c56f57de79022928297632435dec2"
-dependencies = [
- "attribute-derive",
- "quote",
- "syn 2.0.79",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -287,22 +208,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "interpolator"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71dd52191aae121e8611f1e8dc3e324dd0dd1dee1e6dd91d10ee07a3cfb4d9d8"
-
-[[package]]
 name = "intervalues"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "counter",
  "defaultmap",
  "itertools",
- "number-general",
+ "num-traits",
  "rand",
  "rust_decimal",
- "rust_decimal_macros",
  "safecast",
 ]
 
@@ -334,70 +248,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
-name = "num"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
-dependencies = [
- "num-bigint",
- "num-complex",
- "num-integer",
- "num-iter",
- "num-rational",
- "num-traits",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
-dependencies = [
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-complex"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
-dependencies = [
- "num-bigint",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -407,33 +257,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "number-general"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "651eff9ed7c67622b62958fa43459c5efc6ed3ed093ac5d0c3057f3bcdb014a3"
-dependencies = [
- "async-trait",
- "collate",
- "get-size",
- "get-size-derive",
- "num",
- "safecast",
-]
-
-[[package]]
 name = "once_cell"
-version = "1.20.1"
+version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82881c4be219ab5faaf2ad5e5e5ecdff8c66bd7402ca3160975c93b24961afd1"
-dependencies = [
- "portable-atomic",
-]
-
-[[package]]
-name = "portable-atomic"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "ppv-lite86"
@@ -462,7 +289,6 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
  "version_check",
 ]
 
@@ -475,17 +301,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "version_check",
-]
-
-[[package]]
-name = "proc-macro-utils"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f59e109e2f795a5070e69578c4dc101068139f74616778025ae1011d4cd41a8"
-dependencies = [
- "proc-macro2",
- "quote",
- "smallvec",
 ]
 
 [[package]]
@@ -524,29 +339,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "quote-use"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7b5abe3fe82fdeeb93f44d66a7b444dedf2e4827defb0a8e69c437b2de2ef94"
-dependencies = [
- "quote",
- "quote-use-macros",
- "syn 2.0.79",
-]
-
-[[package]]
-name = "quote-use-macros"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97ea44c7e20f16017a76a245bb42188517e13d16dcb1aa18044bc406cdc3f4af"
-dependencies = [
- "derive-where",
- "proc-macro2",
- "quote",
- "syn 2.0.79",
 ]
 
 [[package]]
@@ -640,16 +432,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rust_decimal_macros"
-version = "1.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da991f231869f34268415a49724c6578e740ad697ba0999199d6f22b3949332c"
-dependencies = [
- "quote",
- "rust_decimal",
-]
-
-[[package]]
 name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -704,12 +486,6 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
-
-[[package]]
-name = "smallvec"
-version = "1.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "intervalues"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Combine valued intervals together efficiently"
 license = "MIT OR Apache-2.0"
@@ -15,9 +15,8 @@ defaultmap = "0.6.0"
 itertools = "0.13.0"
 rand = "0.8.5"
 rust_decimal = "1.36.0"
-rust_decimal_macros = "1.36.0"
-number-general = "0.12.0"
-safecast = "0.2.2"
+safecast = "0.2.3"
+num-traits = "0.2.19"
 
 [profile.dev]
 opt-level = 3

--- a/src/combine_intervals.rs
+++ b/src/combine_intervals.rs
@@ -1,136 +1,30 @@
 use crate::base_interval::BaseInterval;
+use crate::IntervalCollection;
 use defaultmap::DefaultHashMap;
 use itertools::Itertools;
-use number_general::{Float, Number};
-use rust_decimal::Decimal;
-use safecast::CastFrom;
-use std::collections::HashMap;
-use crate::IntervalCollection;
+use num_traits::{Num, ToPrimitive};
+use std::hash::Hash;
+use std::ops::{AddAssign, SubAssign};
 
-fn intervals_values_to_points(input: Vec<[isize; 3]>) -> Vec<(isize, isize)> {
-    let mut out: DefaultHashMap<isize, isize> = DefaultHashMap::new();
+// TODO: generalize beyond isize
+fn base_intervals_to_points<T, U>(input: Vec<BaseInterval<T, U>>) -> Vec<(T, U)>
+where
+    T: Num + PartialOrd + Clone + Eq + Hash + Copy,
+    U: Num + PartialOrd + Default + AddAssign + SubAssign + Clone + Copy,
+{
+    let mut out: DefaultHashMap<T, U> = DefaultHashMap::new();
     for entry in input.iter() {
-        let mult = if entry[0] > entry[1] { -1 } else { 1 };
-        out[entry[0]] += mult * entry[2];
-        out[entry[1]] -= mult * entry[2];
+        let this = entry.to_tuple();
+        out[this.0] += this.2;
+        out[this.1] -= this.2;
     }
-    let out: Vec<(isize, isize)> = out
+    let mut out: Vec<(T, U)> = out
         .iter()
-        .filter(|x| *x.1 != 0)
-        .sorted()
-        .map(|x| (*x.0, *x.1))
+        .filter(|x| *x.1 != U::zero())
+        .map(|x| (x.0.to_owned(), x.1.to_owned()))
         .collect();
-    out
-}
-
-fn intervals_to_points(input: Vec<[isize; 2]>) -> Vec<(isize, isize)> {
-    let mut out: DefaultHashMap<isize, isize> = DefaultHashMap::new();
-    for entry in input.iter() {
-        let mult = if entry[0] > entry[1] { -1 } else { 1 };
-        out[entry[0]] += mult;
-        out[entry[1]] -= mult;
-    }
-    let out: Vec<(isize, isize)> = out
-        .iter()
-        .filter(|x| *x.1 != 0)
-        .sorted()
-        .map(|x| (*x.0, *x.1))
-        .collect();
-    out
-}
-
-/// Combine intervals with values to an efficient and reduced collection.
-/// This is the isize implementation for valued intervals.
-///
-/// # Examples
-///
-/// ```
-/// use std::collections::HashMap;
-/// use intervalues;
-///
-/// // Two intervals, from 0 to 2 with count 1 and 1 to 3 with count 2
-/// let input: Vec<[isize; 3]> = vec!([0, 2, 1], [1, 3, 2]);
-/// let out: HashMap<(isize, isize), isize> = intervalues::combine_intervals_isize(input);
-///
-/// // 'out' = {(0, 1): 1, (2, 3): 2, (1, 2): 3}
-/// assert_eq!(out[&(0, 1)], 1);
-/// assert_eq!(out[&(1, 2)], 3);
-/// assert_eq!(out[&(2, 3)], 2);
-/// ```
-pub fn combine_intervals_isize(raw_ivs: Vec<[isize; 3]>) -> HashMap<(isize, isize), isize> {
-    // Convert input intervals to point counts
-    let endpoints = intervals_values_to_points(raw_ivs);
-
-    // Convert point counts to cumulative point counts
-    let mut curr_val = 0;
-    let mut new_map = Vec::new();
-    for pt in endpoints {
-        curr_val += pt.1;
-        new_map.push((pt.0, curr_val))
-    }
-
-    // Convert cumulative point counts to intervals
-    let mut out = HashMap::new();
-    for (lb, ub) in new_map.iter().tuple_windows() {
-        if lb.1 != 0 {
-            out.insert((lb.0, ub.0), lb.1);
-        }
-    }
-    out
-}
-
-/// Combine intervals with counts to an efficient and reduced collection.
-/// This is the isize implementation for unvalued intervals.
-///
-/// # Examples
-///
-/// ```
-/// use std::collections::HashMap;
-/// use intervalues;
-///
-/// // Two intervals, from 0 to 2 with count 1 and 1 to 3 with count 2
-/// let input: Vec<[isize; 2]> = vec!([0, 2], [1, 3]);
-/// let out: HashMap<(isize, isize), isize> = intervalues::combine_intervals_isize_no_val(input);
-///
-/// // 'out' = {(0, 1): 1, (2, 3): 2, (1, 2): 3}
-/// assert_eq!(out[&(0, 1)], 1);
-/// assert_eq!(out[&(1, 2)], 2);
-/// assert_eq!(out[&(2, 3)], 1);
-/// ```
-pub fn combine_intervals_isize_no_val(raw_ivs: Vec<[isize; 2]>) -> HashMap<(isize, isize), isize> {
-    // Convert input intervals to point counts
-    let endpoints = intervals_to_points(raw_ivs);
-
-    // Convert point counts to cumulative point counts
-    let mut curr_val = 0;
-    let mut new_map = Vec::new();
-    for pt in endpoints {
-        curr_val += pt.1;
-        new_map.push((pt.0, curr_val))
-    }
-
-    // Convert cumulative point counts to intervals
-    let mut out = HashMap::new();
-    for (lb, ub) in new_map.iter().tuple_windows() {
-        if lb.1 != 0 {
-            out.insert((lb.0, ub.0), lb.1);
-        }
-    }
-    out
-}
-
-fn base_intervals_to_points(input: Vec<BaseInterval>) -> Vec<(Number, Number)> {
-    let mut out: DefaultHashMap<Number, Number> = DefaultHashMap::new();
-    for entry in input.iter() {
-        out[entry.get_lb()] += entry.get_value();
-        out[entry.get_ub()] -= entry.get_value();
-    }
-    let mut out: Vec<(Number, Number)> = out
-        .iter()
-        .filter(|x| *x.1 != Number::from(0.0))
-        .map(|x| (*x.0, *x.1))
-        .collect();
-    out.sort_by_key(|x| Decimal::from_f64_retain(f64::cast_from(Float::cast_from(x.0))));
+    out.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    // out.sort_unstable_by(|a, b| a.partial_cmp(b).unwrap());
     out
 }
 
@@ -141,26 +35,38 @@ fn base_intervals_to_points(input: Vec<BaseInterval>) -> Vec<(Number, Number)> {
 ///
 /// ```
 /// use std::collections::HashMap;
-/// use number_general::Number;
 /// use intervalues;
 /// use intervalues::{BaseInterval, IntervalCollection};
 ///
 /// // Two intervals, from 0 to 2 with count 1 and 1 to 3 with count 2
 /// let input: Vec<[i64; 3]> = vec!([0, 2, 1], [1, 3, 2]);
 /// let input = input.iter()
-///     .map(|x| BaseInterval::new(Number::from(x[0]), Number::from(x[1]), Number::from(x[2])))
+///     .map(|x| BaseInterval::new(x[0], x[1], x[2]))
 ///     .collect();
-/// let out: IntervalCollection = intervalues::combine_intervals(input);
+/// let out: IntervalCollection<i64,i64> = intervalues::combine_intervals(input);
 ///
 /// // 'out' = {(0, 1, 1), (2, 3, 2), (1, 2, 3)}
 /// assert_eq!(out.to_vec_as_counter()[0], BaseInterval::default());
-/// assert_eq!(out.to_vec_owned()[1], BaseInterval::new(Number::from(1), Number::from(2), Number::from(3)));
+/// assert_eq!(out.to_vec_owned()[1], BaseInterval::new(1, 2, 3));
 /// ```
-pub fn combine_intervals(raw_ivs: Vec<BaseInterval>) -> IntervalCollection {
-    let endpoints: Vec<(Number, Number)> = base_intervals_to_points(raw_ivs);
+pub fn combine_intervals<T, U>(raw_ivs: Vec<BaseInterval<T, U>>) -> IntervalCollection<T, U>
+//Vec<BaseInterval<T, U>>
+where
+    T: Num + PartialOrd + Clone + Hash + Copy + Eq,
+    U: Num
+        + PartialOrd
+        + Default
+        + AddAssign
+        + SubAssign
+        + Clone
+        + Copy
+        + ToPrimitive
+        + std::iter::Sum,
+{
+    let endpoints: Vec<(T, U)> = base_intervals_to_points(raw_ivs); // TODO: generalize beyond isize
 
     // Convert point counts to cumulative point counts
-    let mut curr_val = Number::from(0);
+    let mut curr_val = U::zero();
     let mut new_map = Vec::new();
     for pt in endpoints {
         curr_val += pt.1;
@@ -170,7 +76,7 @@ pub fn combine_intervals(raw_ivs: Vec<BaseInterval>) -> IntervalCollection {
     // Convert cumulative point counts to intervals
     let mut out = Vec::new();
     for (lb, ub) in new_map.iter().tuple_windows() {
-        if lb.1 != Number::from(0.0) {
+        if lb.1 != U::zero() {
             out.push(BaseInterval::new(lb.0, ub.0, lb.1));
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,11 +5,7 @@
 mod base_interval;
 mod combine_intervals;
 mod interval_collection;
-// mod archive;
 
-pub use crate::combine_intervals::{
-    combine_intervals, combine_intervals_isize, combine_intervals_isize_no_val,
-};
-// pub use crate::archive::combine_intervals_general;
+pub use crate::combine_intervals::combine_intervals;
 pub use crate::base_interval::BaseInterval;
 pub use crate::interval_collection::IntervalCollection;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,8 @@
 use intervalues;
 use intervalues::BaseInterval;
-use itertools::Itertools;
-use number_general::Number;
+use num_traits::ToPrimitive;
 use rand::Rng;
+use rust_decimal::Decimal;
 use std::time::Instant;
 
 fn main() {
@@ -14,82 +14,57 @@ fn main() {
     println!("What follows are variations of combining 1 000 000 intervals between 0 and 9:");
 
     println!(
-        "\n(1) Unvalued and using <isize> typed interval borders. Returns HashMap<(lb,ub),val>."
-    );
-    let mut input: Vec<[isize; 2]> = Vec::new();
-    for _ in 0..1000000 {
-        input.push([rng.gen_range(0..10), rng.gen_range(0..10)])
-    }
-    let before = Instant::now();
-    let hi = intervalues::combine_intervals_isize_no_val(input);
-    let after = Instant::now();
-    println!("{:?} in {:?}", hi, after - before);
-
-    println!(
-        "\n(2) Valued and using <isize> typed interval borders, value set to 1 for all. \
-    Returns HashMap<(lb,ub),val>."
-    );
-    let mut input: Vec<[isize; 3]> = Vec::new();
-    for _ in 0..1000000 {
-        input.push([rng.gen_range(0..10), rng.gen_range(0..10), 1])
-    }
-    let before = Instant::now();
-    let hi = intervalues::combine_intervals_isize(input);
-    let after = Instant::now();
-    println!("{:?} in {:?}", hi, after - before);
-
-    // println!("\n(3) Unvalued and using <f64> typed interval borders. Returns Vec<(lb,ub,val)>");
-    // let mut input: Vec<[f64; 2]> = Vec::new();
-    // for _ in 0..1000000 {
-    //     input.push([rng.gen_range(0..10) as f64, rng.gen_range(0..10) as f64])
-    // }
-    // let before = Instant::now();
-    // let hi = intervalues::combine_intervals_flt(input);
-    // let after = Instant::now();
-    // println!("{:?} in {:?}", hi, after - before);
-    //
-    // println!("\n(4) Valued and using <f64> typed interval borders, value set to 1.0 for all. \
-    // Returns Vec<(lb,ub,val)>");
-    // let mut input: Vec<[f64; 3]> = Vec::new();
-    // for _ in 0..1000000 {
-    //     input.push([rng.gen_range(0..10) as f64, rng.gen_range(0..10) as f64, 1.0])
-    // }
-    // let before = Instant::now();
-    // let hi = intervalues::combine_intervals_flt_values(input);
-    // let after = Instant::now();
-    // println!("{:?} in {:?}", hi, after - before);
-    //
-    // println!("\n(5) Valued and using Number typed interval borders, value set to 1.0 for all. \
-    // Returns BaseInterval(lb,ub,val)]");
-    // let mut input: Vec<[Number; 3]> = Vec::new();
-    // for _ in 0..1000000 {
-    //     input.push([Number::from(rng.gen_range(0..10)),
-    //         Number::from(rng.gen_range(0..10)),
-    //         Number::from(1)])
-    // }
-    // let before = Instant::now();
-    // let hi = intervalues::combine_intervals_general(input);
-    // let after = Instant::now();
-    // println!("{:?} in {:?}", hi, after - before);
-
-    println!(
-        "\n(6) Valued and using Number typed interval borders, value set to 1.0 for all. \
+        "\n(1) Valued and using i32 typed interval borders, value set to 1 for all. \
     Converts to BaseInterval and returns IntervalCollection"
     );
-    let mut input: Vec<BaseInterval> = Vec::new();
-    for _ in 0..1000000 {
+    let mut input = Vec::new();
+    let n = 1000000;
+    for _ in 0..n {
         input.push(BaseInterval::new(
-            Number::from(rng.gen_range(0..10)),
-            Number::from(rng.gen_range(0..10)),
-            Number::from(1),
+            rng.gen_range(0..10),
+            rng.gen_range(0..10),
+            1,
         ));
     }
     let before = Instant::now();
     let hi = intervalues::combine_intervals(input);
     let after = Instant::now();
+    println!("{:?} in {:?}", hi, after - before);
+
     println!(
-        "{:?} in {:?}",
-        hi.to_vec().iter().map(|x| x.to_array()).collect_vec(),
-        after - before
+        "\n(2) Valued and using i32 typed interval borders, value set to Decimal 1.5 for all. \
+    Converts to BaseInterval and returns IntervalCollection"
     );
+    let mut input = Vec::new();
+    let n = 1000000;
+    for _ in 0..n {
+        input.push(BaseInterval::new(
+            rng.gen_range(0..10),
+            rng.gen_range(0..10),
+            // 1),
+            Decimal::from_f32_retain(1.5).unwrap(),
+        ));
+    }
+    let before = Instant::now();
+    let hi = intervalues::combine_intervals(input);
+    let after = Instant::now();
+    println!("{:?} in {:?}", hi, after - before);
+
+    println!(
+        "\n(3) Valued and using Decimal (via float) typed interval borders, value set to Decimal(1.5) for all. \
+    Converts to BaseInterval and returns IntervalCollection"
+    );
+    let mut input = Vec::new();
+    let n = 1000000;
+    for _ in 0..n {
+        input.push(BaseInterval::new(
+            Decimal::from_f32_retain(0.5 + rng.gen_range(0..10).to_f32().unwrap()).unwrap(),
+            Decimal::from_f32_retain(0.5 + rng.gen_range(0..10).to_f32().unwrap()).unwrap(),
+            Decimal::from_f32_retain(1.5).unwrap(),
+        ));
+    }
+    let before = Instant::now();
+    let hi = intervalues::combine_intervals(input);
+    let after = Instant::now();
+    println!("{:?} in {:?}", hi, after - before);
 }


### PR DESCRIPTION
Implement #10

For this, use traits, which will allow for the fast isize (or i32, i64, usize, u8 etc) calculations but also will supports floats (after converting to Decimals for now, due to needing Hash and Eq traits in the current implementation).

I will see if this can be circumvented in the future.