### PR TITLE
Add distinct valueless interval

### DIFF
--- a/src/combine_intervals.rs
+++ b/src/combine_intervals.rs
@@ -1,4 +1,4 @@
-use crate::base_interval::BaseInterval;
+use crate::base_interval::Interval;
 use crate::IntervalCollection;
 use defaultmap::DefaultHashMap;
 use itertools::Itertools;
@@ -6,7 +6,7 @@ use num_traits::{Num, ToPrimitive};
 use std::hash::Hash;
 use std::ops::{AddAssign, SubAssign};
 
-fn base_intervals_to_points<T, U>(input: Vec<BaseInterval<T, U>>) -> Vec<(T, U)>
+fn base_intervals_to_points<T, U>(input: Vec<Interval<T, U>>) -> Vec<(T, U)>
 where
     T: Num + PartialOrd + Clone + Eq + Hash + Copy,
     U: Num + PartialOrd + Default + AddAssign + SubAssign + Clone + Copy,
@@ -34,20 +34,20 @@ where
 /// ```
 /// use std::collections::HashMap;
 /// use intervalues;
-/// use intervalues::{BaseInterval, IntervalCollection};
+/// use intervalues::{Interval, IntervalCollection};
 ///
 /// // Two intervals, from 0 to 2 with count 1 and 1 to 3 with count 2
 /// let input: Vec<[i64; 3]> = vec!([0, 2, 1], [1, 3, 2]);
 /// let input = input.iter()
-///     .map(|x| BaseInterval::new(x[0], x[1], x[2]))
+///     .map(|x| Interval::new(x[0], x[1], x[2]))
 ///     .collect();
 /// let out: IntervalCollection<i64,i64> = intervalues::combine_intervals(input);
 ///
 /// // 'out' = {(0, 1, 1), (2, 3, 2), (1, 2, 3)}
-/// assert_eq!(out.to_vec_as_counter()[0], BaseInterval::default());
-/// assert_eq!(out.to_vec_owned()[1], BaseInterval::new(1, 2, 3));
+/// assert_eq!(out.to_vec_as_counter()[0], Interval::default());
+/// assert_eq!(out.to_vec_owned()[1], Interval::new(1, 2, 3));
 /// ```
-pub fn combine_intervals<T, U>(raw_ivs: Vec<BaseInterval<T, U>>) -> IntervalCollection<T, U>
+pub fn combine_intervals<T, U>(raw_ivs: Vec<Interval<T, U>>) -> IntervalCollection<T, U>
 //Vec<BaseInterval<T, U>>
 where
     T: Num + PartialOrd + Clone + Hash + Copy + Eq,
@@ -75,7 +75,7 @@ where
     let mut out = Vec::new();
     for (lb, ub) in new_map.iter().tuple_windows() {
         if lb.1 != U::zero() {
-            out.push(BaseInterval::new(lb.0, ub.0, lb.1));
+            out.push(Interval::new(lb.0, ub.0, lb.1));
         }
     }
     IntervalCollection::from_vec(out)

--- a/src/combine_intervals.rs
+++ b/src/combine_intervals.rs
@@ -1,4 +1,4 @@
-use crate::base_interval::Interval;
+use crate::interval::Interval;
 use crate::IntervalCollection;
 use defaultmap::DefaultHashMap;
 use itertools::Itertools;

--- a/src/interval.rs
+++ b/src/interval.rs
@@ -1,0 +1,245 @@
+use num_traits::{Num, ToPrimitive};
+use std::cmp::PartialOrd;
+use crate::BaseInterval;
+
+#[derive(Clone, Copy, Hash, Eq, PartialEq, Debug)]
+pub struct Interval<T: Num, U: Num> {
+    lb: T,
+    ub: T,
+    val: U,
+}
+
+impl<T, U> Default for Interval<T, U>
+where
+    T: Num + PartialOrd + Clone,
+    U: Num,
+{
+    fn default() -> Self {
+        Interval {
+            lb: T::zero(),
+            ub: T::one(),
+            val: U::one(),
+        }
+    }
+}
+
+
+impl<T, U> Interval<T, U>
+where
+    T: Num + PartialOrd + Clone,
+    U: Num + PartialOrd,
+{
+    pub fn new(lb: T, ub: T, val: U) -> Self {
+        if ub > lb {
+            Interval { lb, ub, val }
+        } else {
+            Interval {
+                lb: ub,
+                ub: lb,
+                val,
+            }
+        }
+    }
+
+    pub fn to_tuple(self) -> (T, T, U) {
+        (self.lb, self.ub, self.val)
+    }
+
+    pub fn get_bounds(self) -> (T, T) {
+        (self.lb, self.ub)
+    }
+
+    pub fn get_lb(self) -> T {
+        self.lb
+    }
+
+    pub fn get_ub(self) -> T {
+        self.ub
+    }
+
+    pub fn get_width(self) -> T {
+        self.ub - self.lb
+    }
+
+    pub fn get_value(self) -> U {
+        self.val
+    }
+
+    pub fn len(self) -> T {
+        self.ub - self.lb
+    }
+
+    pub fn contains(self, num: T) -> bool {
+        if (num >= self.lb) & (num <= self.ub) {
+            true
+        } else {
+            false
+        }
+    }
+
+    // TODO explore if T can be U here
+    pub fn superset(self, other: Interval<T, U>) -> bool {
+        if (other.ub <= self.ub) && (other.lb >= self.lb) {
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn subset(self, other: Interval<T, U>) -> bool {
+        other.superset(self)
+    }
+
+    pub fn left_overlaps(&self, other: &Interval<T, U>) -> bool {
+        if (self.lb <= other.lb) & (self.ub <= other.ub) {
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn right_overlaps(self, other: &Interval<T, U>) -> bool {
+        other.left_overlaps(&self)
+    }
+
+    pub fn overlaps(self, other: Interval<T, U>) -> bool {
+        self.left_overlaps(&other) || self.right_overlaps(&other)
+    }
+
+    pub fn can_join(self, other: &Interval<T, U>) -> bool {
+        if ((self.ub == other.lb) || (other.ub == self.lb)) && (self.val == other.val) {
+            true
+        } else if (self.ub == other.ub) && (self.lb == other.lb) {
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn join(self, other: Interval<T, U>) -> Interval<T, U> {
+        // Two options to enter this -> same range, or bordering range but same val
+        // So test (and if so, return for) option 1, and then continue with option 2
+        if (self.ub == other.ub) && (self.lb == other.lb) {
+            return Interval::new(self.lb, self.ub, self.val + other.val);
+        }
+
+        // Option 2 from above
+        let (lb, ub) = if self.lb < other.lb {
+            (self.lb, other.ub)
+        } else {
+            (other.lb, self.ub)
+        };
+        Interval::new(lb, ub, self.val)
+    }
+
+    pub fn can_join_as_set(self, other: &Interval<T, U>) -> bool {
+        if (self.ub == other.lb) || (other.ub == self.lb) {
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn join_ign_value(self, other: Interval<T, U>) -> Interval<T, U> {
+        let lb = if self.lb < other.lb {
+            self.lb
+        } else {
+            other.lb
+        };
+        let ub = if self.ub > other.ub {
+            self.ub
+        } else {
+            other.ub
+        };
+        Interval::new(lb, ub, U::one())
+    }
+
+
+    pub fn join_as_set(self, other: Interval<T, U>) -> BaseInterval<T> {
+        let lb = if self.lb < other.lb {
+            self.lb
+        } else {
+            other.lb
+        };
+        let ub = if self.ub > other.ub {
+            self.ub
+        } else {
+            other.ub
+        };
+        BaseInterval::new(lb, ub)
+    }
+
+    pub fn to_base(self) -> BaseInterval<T> {
+        BaseInterval::new(self.lb, self.ub)
+    }
+}
+
+impl<T> Interval<T, T>
+where
+    T: Num,
+{
+    pub fn get_total_value(self) -> T {
+        (self.ub - self.lb) * self.val
+    }
+}
+
+impl<T, U> Interval<T, U>
+where
+    T: Num + Clone + PartialOrd,
+    U: Num + PartialOrd + ToPrimitive,
+{
+    pub fn val_to_count(self) -> Interval<T, usize> {
+        // To test if this works
+        if self.val >= U::one() {
+            Interval::new(self.lb, self.ub, self.val.to_usize().unwrap())
+        } else {
+            Interval::new(self.lb, self.ub, 0)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_create_int_interval() {
+        let a = Interval::new(1, 2, 1);
+        assert_eq!(a.len(), 1);
+        assert_eq!(a.get_value(), 1)
+    }
+
+    #[test]
+    fn test_create_float_interval() {
+        let a = Interval::new(1.0, 4.0, 2.0);
+        assert_eq!(a.len(), 3.0);
+        assert_eq!(a.get_value(), 2.0);
+        assert_eq!(a.get_total_value(), 6.0)
+    }
+
+    #[test]
+    fn test_create_mixed_interval() {
+        let a = Interval::new(1.0, 2.0, 1);
+        assert_eq!(a.len(), 1.0);
+        assert_eq!(a.get_value(), 1)
+    }
+
+    #[test]
+    fn test_create_mixed_interval2() {
+        let a = Interval::new(1, 2, 1.0);
+        assert_eq!(a.len(), 1);
+        assert_eq!(a.get_value(), 1.0)
+    }
+
+    #[test]
+    fn test_val_to_count() {
+        let a = Interval::new(1, 2, 1.5);
+        assert_eq!(a.val_to_count().get_value(), 1)
+    }
+
+    #[test]
+    fn test_val_to_count2() {
+        let a = Interval::new(1, 2, 1);
+        assert_eq!(a.val_to_count().get_value(), 1)
+    }
+}

--- a/src/interval_collection.rs
+++ b/src/interval_collection.rs
@@ -1,10 +1,10 @@
-use crate::BaseInterval;
+use crate::Interval;
 use num_traits::{Num, ToPrimitive};
 use safecast::CastInto;
 
 #[derive(Clone, Hash, Eq, PartialEq, Debug)]
 pub struct IntervalCollection<T: Num, U: Num> {
-    intervals: Vec<BaseInterval<T, U>>,
+    intervals: Vec<Interval<T, U>>,
 }
 
 impl<T, U> IntervalCollection<T, U>
@@ -60,7 +60,7 @@ where
         U::zero()
     }
 
-    pub fn contains_interval(&self, interval: BaseInterval<T, U>) -> bool {
+    pub fn contains_interval(&self, interval: Interval<T, U>) -> bool {
         let mut to_check = interval.clone();
         for interval in self.intervals.iter() {
             if interval.superset(to_check) {
@@ -71,7 +71,7 @@ where
                 continue;
             } else {
                 to_check =
-                    BaseInterval::new(interval.get_ub(), to_check.get_ub(), to_check.get_value());
+                    Interval::new(interval.get_ub(), to_check.get_ub(), to_check.get_value());
             }
         }
         false
@@ -79,13 +79,13 @@ where
 
     pub fn get_value_of_interval_by_parts(
         &self,
-        interval: BaseInterval<T, U>,
+        interval: Interval<T, U>,
     ) -> IntervalCollection<T, U> {
         let mut values = Vec::new();
         let mut to_check = interval.clone();
         for interval in self.intervals.iter() {
             if interval.superset(to_check) {
-                let new = BaseInterval::new(
+                let new = Interval::new(
                     to_check.get_lb(),
                     to_check.get_ub(),
                     interval.get_value() / to_check.get_value(),
@@ -98,13 +98,13 @@ where
                 continue;
             } else {
                 to_check =
-                    BaseInterval::new(interval.get_ub(), to_check.get_ub(), to_check.get_value());
+                    Interval::new(interval.get_ub(), to_check.get_ub(), to_check.get_value());
             }
         }
         IntervalCollection::from_vec(values)
     }
 
-    pub fn get_partially_overlaps_interval(&self, other: &BaseInterval<T, U>) -> bool {
+    pub fn get_partially_overlaps_interval(&self, other: &Interval<T, U>) -> bool {
         for interval in self.intervals.iter() {
             if interval.overlaps(*other) {
                 return true;
@@ -122,19 +122,19 @@ where
         false
     }
 
-    pub fn from_vec(vec: Vec<BaseInterval<T, U>>) -> Self {
+    pub fn from_vec(vec: Vec<Interval<T, U>>) -> Self {
         IntervalCollection { intervals: vec }
     }
 
-    pub fn to_vec_owned(self) -> Vec<BaseInterval<T, U>> {
+    pub fn to_vec_owned(self) -> Vec<Interval<T, U>> {
         self.intervals
     }
 
-    pub fn to_vec(self) -> Vec<BaseInterval<T, U>> {
+    pub fn to_vec(self) -> Vec<Interval<T, U>> {
         self.intervals.clone()
     }
 
-    pub fn to_vec_as_set(&self) -> Vec<BaseInterval<T, U>> {
+    pub fn to_vec_as_set(&self) -> Vec<Interval<T, U>> {
         // TODO: create unvalued BI (no U)
         let mut new = Vec::new();
         if self.len() == 0 {
@@ -172,7 +172,7 @@ where
     T: Num + PartialOrd + Clone + Copy,
     U: Num + PartialOrd + Clone + Copy + ToPrimitive + std::iter::Sum,
 {
-    pub fn to_vec_as_counter(&self) -> Vec<BaseInterval<T, usize>> {
+    pub fn to_vec_as_counter(&self) -> Vec<Interval<T, usize>> {
         let mut new = Vec::new();
         if self.len() == 0 {
             return new;

--- a/src/interval_collection.rs
+++ b/src/interval_collection.rs
@@ -1,4 +1,4 @@
-use crate::Interval;
+use crate::{BaseInterval, Interval};
 use num_traits::{Num, ToPrimitive};
 use safecast::CastInto;
 
@@ -134,7 +134,7 @@ where
         self.intervals.clone()
     }
 
-    pub fn to_vec_as_set(&self) -> Vec<Interval<T, U>> {
+    pub fn to_vec_as_set(&self) -> Vec<BaseInterval<T>> {
         // TODO: create unvalued BI (no U)
         let mut new = Vec::new();
         if self.len() == 0 {
@@ -142,14 +142,14 @@ where
         }
         let mut this_interval = self.intervals[0];
         for next_interval in self.intervals[1..].iter() {
-            if this_interval.can_join_ign_value(next_interval) {
+            if this_interval.can_join_as_set(next_interval) {
                 this_interval = this_interval.join_ign_value(*next_interval);
             } else {
-                new.push(this_interval);
+                new.push(this_interval.to_base());
                 this_interval = *next_interval;
             }
         }
-        new.push(this_interval);
+        new.push(this_interval.to_base());
         new
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,6 @@ mod base_interval;
 mod combine_intervals;
 mod interval_collection;
 
-pub use crate::base_interval::BaseInterval;
+pub use crate::base_interval::Interval;
 pub use crate::combine_intervals::combine_intervals;
 pub use crate::interval_collection::IntervalCollection;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,9 +3,11 @@
 //! `intervalues` brings functionality to combine valued intervals together in an efficient manner.
 
 mod base_interval;
+mod interval;
 mod combine_intervals;
 mod interval_collection;
 
-pub use crate::base_interval::Interval;
+pub use crate::base_interval::BaseInterval;
+pub use crate::interval::Interval;
 pub use crate::combine_intervals::combine_intervals;
 pub use crate::interval_collection::IntervalCollection;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use intervalues;
-use intervalues::BaseInterval;
+use intervalues::Interval;
 use num_traits::ToPrimitive;
 use rand::Rng;
 use rust_decimal::Decimal;
@@ -20,7 +20,7 @@ fn main() {
     let mut input = Vec::new();
     let n = 1000000;
     for _ in 0..n {
-        input.push(BaseInterval::new(
+        input.push(Interval::new(
             rng.gen_range(0..10),
             rng.gen_range(0..10),
             1,
@@ -38,7 +38,7 @@ fn main() {
     let mut input = Vec::new();
     let n = 1000000;
     for _ in 0..n {
-        input.push(BaseInterval::new(
+        input.push(Interval::new(
             rng.gen_range(0..10),
             rng.gen_range(0..10),
             // 1),
@@ -57,7 +57,7 @@ fn main() {
     let mut input = Vec::new();
     let n = 1000000;
     for _ in 0..n {
-        input.push(BaseInterval::new(
+        input.push(Interval::new(
             Decimal::from_f32_retain(0.5 + rng.gen_range(0..10).to_f32().unwrap()).unwrap(),
             Decimal::from_f32_retain(0.5 + rng.gen_range(0..10).to_f32().unwrap()).unwrap(),
             Decimal::from_f32_retain(1.5).unwrap(),


### PR DESCRIPTION
Add distinct valueless interval:
- Rename BaseInterval to Interval (**with** value) and move to `interval.rs`
- Add new BaseInterval (**without** value) into `base_interval.rs`
- Make use of new BaseInterval when making an IntervalSet
- Stick to Interval (old BaseInterval) for all other Collections.