### PR TITLE
Add direct set combination (#15)

### DIFF
--- a/src/combine_intervals.rs
+++ b/src/combine_intervals.rs
@@ -253,4 +253,21 @@ mod tests {
         let that = combine_as_set(that);
         assert_eq!(this, that);
     }
+
+    #[test]
+    fn test_as_set_both_impls() {
+        let that: Vec<[i64; 3]> = vec![[0, 2, 1], [1, 3, 2]];
+        let that = that
+            .iter()
+            .map(|x| Interval::new(x[0], x[1], x[2]))
+            .collect();
+        let this = combine_as_set(that);
+        let that: Vec<[i64; 3]> = vec![[0, 2, 1], [1, 3, 2]];
+        let that = that
+            .iter()
+            .map(|x| Interval::new(x[0], x[1], x[2]))
+            .collect();
+        let that = combine_intervals(that).to_vec_as_set();
+        assert_eq!(this, that);
+    }
 }

--- a/src/combine_intervals.rs
+++ b/src/combine_intervals.rs
@@ -1,16 +1,17 @@
 use crate::interval::Interval;
-use crate::IntervalCollection;
+use crate::{BaseInterval, IntervalCollection};
 use defaultmap::DefaultHashMap;
 use itertools::Itertools;
 use num_traits::{Num, ToPrimitive};
+use std::fmt::Debug;
 use std::fmt::Display;
 use std::hash::Hash;
 use std::ops::{AddAssign, SubAssign};
 
-fn base_intervals_to_points<T, U>(input: Vec<Interval<T, U>>) -> Vec<(T, U)>
+fn intervals_to_points<T, U>(input: Vec<Interval<T, U>>) -> Vec<(T, U)>
 where
-    T: Num + PartialOrd + Clone + Eq + Hash + Copy + Display,
-    U: Num + PartialOrd + Default + AddAssign + SubAssign + Clone + Copy + Display,
+    T: Num + PartialOrd + Clone + Eq + Hash + Copy + Display + Debug,
+    U: Num + PartialOrd + Default + AddAssign + SubAssign + Clone + Copy + Display + Debug,
 {
     let mut out: DefaultHashMap<T, U> = DefaultHashMap::new();
     for entry in input.iter() {
@@ -23,7 +24,7 @@ where
         .filter(|x| *x.1 != U::zero())
         .map(|x| (x.0.to_owned(), x.1.to_owned()))
         .collect();
-    out.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    out.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
     out
 }
 
@@ -49,9 +50,8 @@ where
 /// assert_eq!(out.to_vec_owned()[1], Interval::new(1, 2, 3));
 /// ```
 pub fn combine_intervals<T, U>(raw_ivs: Vec<Interval<T, U>>) -> IntervalCollection<T, U>
-//Vec<BaseInterval<T, U>>
 where
-    T: Num + PartialOrd + Clone + Hash + Copy + Eq + Display,
+    T: Num + PartialOrd + Clone + Hash + Copy + Eq + Display + Debug,
     U: Num
         + PartialOrd
         + Default
@@ -61,9 +61,10 @@ where
         + Copy
         + ToPrimitive
         + std::iter::Sum
-        + Display,
+        + Display
+        + Debug,
 {
-    let endpoints: Vec<(T, U)> = base_intervals_to_points(raw_ivs);
+    let endpoints: Vec<(T, U)> = intervals_to_points(raw_ivs);
 
     // Convert point counts to cumulative point counts
     let mut curr_val = U::zero();
@@ -81,6 +82,74 @@ where
         }
     }
     IntervalCollection::from_vec(out)
+}
+
+/// Combine intervals with values to an efficient and reduced collection, taking overlaps and
+/// duplicates into account. This version returns the intervals with a positive final value.
+/// Returns a Vec of BaseIntervals.
+///
+/// # Examples
+///
+/// ```
+/// use std::collections::HashMap;
+/// use intervalues::{Interval, IntervalCollection, combine_intervals, combine_as_set, BaseInterval};
+///
+/// // Two intervals, from 0 to 2 with count 1 and 1 to 3 with count 2
+/// let input: Vec<[i64; 3]> = vec!([0, 2, 1], [1, 3, 2]);
+/// let input = input.iter()
+///     .map(|x| Interval::new(x[0], x[1], x[2]))
+///     .collect();
+/// let out: Vec<BaseInterval<i64>> = combine_as_set(input);
+///
+/// // 'out' = {(0, 1, 1), (2, 3, 2), (1, 2, 3)}
+/// assert_eq!(out[0], BaseInterval::new(0, 3));
+/// ```
+pub fn combine_as_set<T, U>(raw_ivs: Vec<Interval<T, U>>) -> Vec<BaseInterval<T>>
+where
+    T: Num + PartialOrd + Clone + Hash + Copy + Eq + Display + Debug,
+    U: Num
+        + PartialOrd
+        + Default
+        + AddAssign
+        + SubAssign
+        + Clone
+        + Copy
+        + ToPrimitive
+        + std::iter::Sum
+        + Display
+        + Debug,
+{
+    let endpoints: Vec<(T, U)> = intervals_to_points(raw_ivs);
+
+    // Convert point counts to cumulative point counts
+    let mut curr_val = U::zero();
+    let mut new_map = Vec::new();
+    for pt in endpoints {
+        curr_val += pt.1;
+        new_map.push((pt.0, curr_val))
+    }
+
+    // Convert cumulative point counts to intervals
+    let mut out = Vec::new();
+    for (lb, ub) in new_map.iter().tuple_windows() {
+        if lb.1 > U::zero() {
+            match out.last() {
+                None => {
+                    out.push(BaseInterval::new(lb.0, ub.0));
+                }
+                Some(x) => {
+                    if x.get_ub() == lb.0 {
+                        let new_lb = x.get_lb();
+                        out.pop();
+                        out.push(BaseInterval::new(new_lb, ub.0));
+                    } else {
+                        out.push(BaseInterval::new(lb.0, ub.0));
+                    }
+                }
+            }
+        }
+    }
+    out
 }
 
 #[cfg(test)]
@@ -135,6 +204,53 @@ mod tests {
             .map(|x| Interval::new(x[0], x[1], x[2]))
             .collect();
         let that = combine_intervals(that);
+        assert_eq!(this, that);
+    }
+
+    #[test]
+    fn test_merge() {
+        let this: Vec<[i64; 3]> = vec![[0, 1, 2], [1, 2, 2]];
+        let this = this
+            .iter()
+            .map(|x| Interval::new(x[0], x[1], x[2]))
+            .collect();
+        let this = combine_intervals(this);
+        let that: Vec<[i64; 3]> = vec![[0, 2, 2]];
+        let that = that
+            .iter()
+            .map(|x| Interval::new(x[0], x[1], x[2]))
+            .collect();
+        let that = IntervalCollection::from_vec(that);
+        assert_eq!(this, that);
+    }
+
+    #[test]
+    fn test_set_with_overlap() {
+        let this: Vec<[i64; 3]> = vec![[0, 2, 1], [1, 3, 2]];
+        let this = this
+            .iter()
+            .map(|x| Interval::new(x[0], x[1], x[2]))
+            .collect();
+        let this = combine_as_set(this);
+        let that: Vec<[i64; 2]> = vec![[0, 3]];
+        let that: Vec<BaseInterval<i64>> =
+            that.iter().map(|x| BaseInterval::new(x[0], x[1])).collect();
+        assert_eq!(this, that);
+    }
+
+    #[test]
+    fn test_set_without_overlap() {
+        let this: Vec<[i64; 2]> = vec![[0, 1], [2, 3]];
+        let this: Vec<BaseInterval<i64>> = this
+            .iter()
+            .map(|x| BaseInterval::new(x[0], x[1]))
+            .collect();
+        let that: Vec<[i64; 3]> = vec![[0, 1, 1], [2, 3, 2]];
+        let that = that
+            .iter()
+            .map(|x| Interval::new(x[0], x[1], x[2]))
+            .collect();
+        let that = combine_as_set(that);
         assert_eq!(this, that);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ mod interval_collection;
 mod intfloat;
 
 pub use crate::base_interval::BaseInterval;
-pub use crate::combine_intervals::combine_intervals;
+pub use crate::combine_intervals::{combine_as_set, combine_intervals};
 pub use crate::interval::Interval;
 pub use crate::interval_collection::IntervalCollection;
 pub use crate::intfloat::IntFloat;


### PR DESCRIPTION
Add direct set combination (as in #15) that avoids some calculations. 

So these should be the same:
- `combine_as_set(interval_vec)`
- `combine_intervals(interval_vec).to_vec_as_set()`